### PR TITLE
replace memmap for memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ fork = ["anyhow", "errno"]
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 tempfile = "3"
-memmap = "0.7"
+memmap2 = "0.2"
 libc = "0.2"
 thiserror = "1"
 anyhow = { version = "1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![deny(warnings)]
 
-use memmap::MmapMut;
+use memmap2::MmapMut;
 use os::{Buffer, Header, View};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Result};
-use memmap::MmapMut;
+use memmap2::MmapMut;
 use std::{
     cell::UnsafeCell,
     mem::MaybeUninit,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,5 @@
 use crate::{bitmask::BitMask, Error, Result};
-use memmap::MmapMut;
+use memmap2::MmapMut;
 use sha2::{Digest, Sha256};
 use std::{
     cell::UnsafeCell,


### PR DESCRIPTION
memmap has not had any updates in more than two years.
And memmap2, which is a fork of the former, has had recent upgrades.