### PR TITLE
Generalizing ser/deser to use traits

### DIFF
--- a/examples/ipmpsc-receive.rs
+++ b/examples/ipmpsc-receive.rs
@@ -2,7 +2,7 @@
 
 use clap::{App, Arg};
 use ipmpsc::{Receiver, SharedRingBuffer, ShmDeserializer, ShmZeroCopyDeserializer};
-use serde::{Deserialize};
+use serde::Deserialize;
 
 #[derive(Debug)]
 pub struct BincodeZeroCopyDeserializer<T>(pub T);
@@ -11,7 +11,9 @@ impl<'de, T> ShmZeroCopyDeserializer<'de> for BincodeZeroCopyDeserializer<T>
 where
     T: Deserialize<'de>,
 {
-    fn deserialize_from_bytes(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+    type Error = bincode::Error;
+
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
         Ok(Self(bincode::deserialize::<T>(bytes)?))
     }
 }
@@ -20,13 +22,15 @@ where
 pub struct BincodeDeserializer<T>(pub T);
 
 impl<T> ShmDeserializer for BincodeDeserializer<T>
-where T: for<'de> Deserialize<'de>
+where
+    T: for<'de> Deserialize<'de>,
 {
-    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+    type Error = bincode::Error;
+
+    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
         Ok(Self(bincode::deserialize::<T>(bytes)?))
     }
 }
-
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = App::new("ipmpsc-send")
@@ -59,7 +63,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         if zero_copy {
-            println!("received {:?}", rx.zero_copy_context().recv::<BincodeZeroCopyDeserializer<&str>>()?);
+            println!(
+                "received {:?}",
+                rx.zero_copy_context()
+                    .recv::<BincodeZeroCopyDeserializer<&str>>()?
+            );
         } else {
             println!("received {:?}", rx.recv::<BincodeDeserializer<String>>()?);
         }

--- a/examples/ipmpsc-receive.rs
+++ b/examples/ipmpsc-receive.rs
@@ -1,7 +1,32 @@
 #![deny(warnings)]
 
 use clap::{App, Arg};
-use ipmpsc::{Receiver, SharedRingBuffer};
+use ipmpsc::{Receiver, SharedRingBuffer, ShmDeserializer, ShmZeroCopyDeserializer};
+use serde::{Deserialize};
+
+#[derive(Debug)]
+pub struct BincodeZeroCopyDeserializer<T>(pub T);
+
+impl<'de, T> ShmZeroCopyDeserializer<'de> for BincodeZeroCopyDeserializer<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+        Ok(Self(bincode::deserialize::<T>(bytes)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct BincodeDeserializer<T>(pub T);
+
+impl<T> ShmDeserializer for BincodeDeserializer<T>
+where T: for<'de> Deserialize<'de>
+{
+    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+        Ok(Self(bincode::deserialize::<T>(bytes)?))
+    }
+}
+
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = App::new("ipmpsc-send")
@@ -34,9 +59,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         if zero_copy {
-            println!("received {:?}", rx.zero_copy_context().recv::<&str>()?);
+            println!("received {:?}", rx.zero_copy_context().recv::<BincodeZeroCopyDeserializer<&str>>()?);
         } else {
-            println!("received {:?}", rx.recv::<String>()?);
+            println!("received {:?}", rx.recv::<BincodeDeserializer<String>>()?);
         }
     }
 }

--- a/examples/ipmpsc-send.rs
+++ b/examples/ipmpsc-send.rs
@@ -1,8 +1,18 @@
 #![deny(warnings)]
 
 use clap::{App, Arg};
-use ipmpsc::{Sender, SharedRingBuffer};
+use ipmpsc::{Sender, SharedRingBuffer, ShmSerializer};
+use serde::Serialize;
 use std::io::{self, BufRead};
+
+#[derive(Debug)]
+pub struct BincodeSerializer<T: Serialize>(pub T);
+
+impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
+    fn serialize(&self) -> ipmpsc::Result<Vec<u8>> {
+        Ok(bincode::serialize(&self.0)?)
+    }
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = App::new("ipmpsc-send")
@@ -29,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Ready!  Enter some lines of text to send them to the receiver.");
 
     while handle.read_line(&mut buffer)? > 0 {
-        tx.send(&buffer)?;
+        tx.send::<BincodeSerializer<&String>>(&BincodeSerializer(&buffer))?;
         buffer.clear();
     }
 

--- a/examples/ipmpsc-send.rs
+++ b/examples/ipmpsc-send.rs
@@ -9,7 +9,9 @@ use std::io::{self, BufRead};
 pub struct BincodeSerializer<T: Serialize>(pub T);
 
 impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
-    fn serialize(&self) -> ipmpsc::Result<Vec<u8>> {
+    type Error = bincode::Error;
+
+    fn serialize(&self) -> std::result::Result<Vec<u8>, Self::Error> {
         Ok(bincode::serialize(&self.0)?)
     }
 }

--- a/ipc-benchmarks/src/lib.rs
+++ b/ipc-benchmarks/src/lib.rs
@@ -43,6 +43,7 @@ impl<'de, T> ShmZeroCopyDeserializer<'de> for BincodeZeroCopyDeserializer<T>
 where
     T: Deserialize<'de>,
 {
+    #[inline(always)]
     fn deserialize_from_bytes(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
         Ok(Self(bincode::deserialize::<T>(bytes)?))
     }
@@ -54,6 +55,7 @@ pub struct BincodeDeserializer<T>(pub T);
 impl<T> ShmDeserializer for BincodeDeserializer<T>
 where T: for<'de> Deserialize<'de>
 {
+    #[inline(always)]
     fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
         Ok(Self(bincode::deserialize::<T>(bytes)?))
     }
@@ -63,6 +65,7 @@ where T: for<'de> Deserialize<'de>
 pub struct BincodeSerializer<T: Serialize>(pub T);
 
 impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
+    #[inline(always)]
     fn serialize(&self) -> ipmpsc::Result<Vec<u8>> {
         Ok(bincode::serialize(&self.0)?)
     }

--- a/ipc-benchmarks/src/lib.rs
+++ b/ipc-benchmarks/src/lib.rs
@@ -2,9 +2,8 @@
 
 extern crate test;
 
-use serde_derive::{Deserialize, Serialize};
-
-use std::time::Duration;
+use ipmpsc::{ShmDeserializer, ShmSerializer, ShmZeroCopyDeserializer};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct YuvFrameInfo {
@@ -37,12 +36,44 @@ pub struct OwnedYuvFrame {
     pub v_pixels: Vec<u8>,
 }
 
+#[derive(Debug)]
+pub struct BincodeZeroCopyDeserializer<T>(pub T);
+
+impl<'de, T> ShmZeroCopyDeserializer<'de> for BincodeZeroCopyDeserializer<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+        Ok(Self(bincode::deserialize::<T>(bytes)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct BincodeDeserializer<T>(pub T);
+
+impl<T> ShmDeserializer for BincodeDeserializer<T>
+where T: for<'de> Deserialize<'de>
+{
+    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+        Ok(Self(bincode::deserialize::<T>(bytes)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct BincodeSerializer<T: Serialize>(pub T);
+
+impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
+    fn serialize(&self) -> ipmpsc::Result<Vec<u8>> {
+        Ok(bincode::serialize(&self.0)?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use anyhow::{anyhow, Error, Result};
     use ipc_channel::ipc;
-    use ipmpsc::{Receiver, Sender, SharedRingBuffer};
+    use ipmpsc::{Receiver, Sender, SharedRingBuffer, ShmDeserializer, ShmSerializer};
     use test::Bencher;
 
     const SMALL: (usize, usize) = (3, 2);
@@ -97,8 +128,8 @@ mod tests {
                 v_pixels: &v_pixels,
             };
 
-            while exit_rx.try_recv::<u8>()?.is_none() {
-                tx.send_timeout(&frame, Duration::from_millis(100))?;
+            while exit_rx.try_recv::<BincodeDeserializer<u8>>()?.is_none() {
+                tx.send_timeout(&BincodeSerializer(&frame), Duration::from_millis(100))?;
             }
 
             Ok(())
@@ -107,20 +138,20 @@ mod tests {
         // wait for first frame to arrive
         {
             let mut context = rx.zero_copy_context();
-            if let Err(e) = context.recv::<YuvFrame>() {
+            if let Err(e) = context.recv::<BincodeZeroCopyDeserializer<YuvFrame>>() {
                 panic!("error receiving: {:?}", e);
             };
         }
 
         bencher.iter(|| {
             let mut context = rx.zero_copy_context();
-            match context.recv::<YuvFrame>() {
+            match context.recv::<BincodeZeroCopyDeserializer<YuvFrame>>() {
                 Err(e) => panic!("error receiving: {:?}", e),
                 Ok(frame) => test::black_box(&frame),
             };
         });
 
-        exit_tx.send(&1_u8)?;
+        exit_tx.send(&BincodeSerializer(1_u8))?;
 
         sender.join().map_err(|e| anyhow!("{:?}", e))??;
 
@@ -147,7 +178,7 @@ mod tests {
             let exit_buffer = SharedRingBuffer::open(&exit_name)?;
             let exit_rx = Receiver::new(exit_buffer);
 
-            while exit_rx.try_recv::<u8>()?.is_none() {
+            while exit_rx.try_recv::<BincodeDeserializer<u8>>()?.is_none() {
                 let y_pixels = vec![128_u8; y_stride(width) * height];
                 let u_pixels = vec![192_u8; uv_stride(width) * height / 2];
                 let v_pixels = vec![255_u8; uv_stride(width) * height / 2];
@@ -166,7 +197,7 @@ mod tests {
                 };
 
                 if let Err(e) = tx.send(frame) {
-                    if exit_rx.try_recv::<u8>()?.is_none() {
+                    if exit_rx.try_recv::<BincodeDeserializer<u8>>()?.is_none() {
                         return Err(Error::from(e));
                     } else {
                         break;
@@ -187,7 +218,7 @@ mod tests {
             };
         });
 
-        exit_tx.send(&1_u8)?;
+        exit_tx.send(&BincodeSerializer(1_u8))?;
 
         while rx.recv().is_ok() {}
 
@@ -239,10 +270,10 @@ mod tests {
             let size = bincode::serialized_size(&frame).unwrap() as usize;
             let mut buffer = vec![0_u8; size];
 
-            while exit_rx.try_recv::<u8>()?.is_none() {
+            while exit_rx.try_recv::<BincodeDeserializer<u8>>()?.is_none() {
                 bincode::serialize_into(&mut buffer as &mut [u8], &frame).unwrap();
                 if let Err(e) = tx.send(&buffer) {
-                    if exit_rx.try_recv::<u8>()?.is_none() {
+                    if exit_rx.try_recv::<BincodeDeserializer<u8>>()?.is_none() {
                         return Err(Error::from(e));
                     } else {
                         break;
@@ -263,7 +294,7 @@ mod tests {
             };
         });
 
-        exit_tx.send(&1_u8)?;
+        exit_tx.send(&BincodeSerializer(1_u8))?;
 
         while rx.recv().is_ok() {}
 

--- a/ipc-benchmarks/src/lib.rs
+++ b/ipc-benchmarks/src/lib.rs
@@ -70,6 +70,8 @@ impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use anyhow::{anyhow, Error, Result};
     use ipc_channel::ipc;

--- a/ipc-benchmarks/src/lib.rs
+++ b/ipc-benchmarks/src/lib.rs
@@ -43,8 +43,10 @@ impl<'de, T> ShmZeroCopyDeserializer<'de> for BincodeZeroCopyDeserializer<T>
 where
     T: Deserialize<'de>,
 {
+    type Error = bincode::Error;
+
     #[inline(always)]
-    fn deserialize_from_bytes(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
         Ok(Self(bincode::deserialize::<T>(bytes)?))
     }
 }
@@ -55,8 +57,10 @@ pub struct BincodeDeserializer<T>(pub T);
 impl<T> ShmDeserializer for BincodeDeserializer<T>
 where T: for<'de> Deserialize<'de>
 {
+    type Error = bincode::Error;
+
     #[inline(always)]
-    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> ipmpsc::Result<Self> {
+    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
         Ok(Self(bincode::deserialize::<T>(bytes)?))
     }
 }
@@ -65,8 +69,10 @@ where T: for<'de> Deserialize<'de>
 pub struct BincodeSerializer<T: Serialize>(pub T);
 
 impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
+    type Error = bincode::Error;
+
     #[inline(always)]
-    fn serialize(&self) -> ipmpsc::Result<Vec<u8>> {
+    fn serialize(&self) -> std::result::Result<Vec<u8>, Self::Error> {
         Ok(bincode::serialize(&self.0)?)
     }
 }

--- a/ipc-benchmarks/src/lib.rs
+++ b/ipc-benchmarks/src/lib.rs
@@ -71,11 +71,10 @@ impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-
     use super::*;
     use anyhow::{anyhow, Error, Result};
     use ipc_channel::ipc;
-    use ipmpsc::{Receiver, Sender, SharedRingBuffer, ShmDeserializer, ShmSerializer};
+    use ipmpsc::{Receiver, Sender, SharedRingBuffer};
     use test::Bencher;
 
     const SMALL: (usize, usize) = (3, 2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub enum Error {
     #[error(transparent)]
     Bincode(#[from] bincode::Error),
 
+    /// Errors from converting little endian bytes to u32 will be caught here.
     #[error(transparent)]
     TryFrom(#[from] TryFromSliceError),
 }
@@ -113,15 +114,21 @@ fn map(file: &File) -> Result<MmapMut> {
     }
 }
 
+/// Trait apis to decouple the serialization backend from the mechanical send/recv
+/// For a writer to work the payload must implement this trait
 pub trait ShmSerializer {
     fn serialize(&self) -> Result<Vec<u8>>;
 }
 
-pub trait ShmZeroCopyDeserializer<'de>: Sized {
-    fn deserialize_from_bytes(bytes: &'de [u8]) -> Result<Self>;
-}
+/// For a reader to work they payload must implement this trait
 pub trait ShmDeserializer: Sized {
     fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self>;
+}
+
+/// To use the zero_copy_context the payload must implement this trait allowing for more
+/// explict lifetimes
+pub trait ShmZeroCopyDeserializer<'de>: Sized {
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> Result<Self>;
 }
 
 /// Represents a file-backed shared memory ring buffer, suitable for constructing a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,11 @@
 
 use memmap2::MmapMut;
 use os::{Buffer, Header, View};
-use serde::{Deserialize, Serialize};
 use std::{
-    cell::UnsafeCell,
-    ffi::c_void,
-    fs::{File, OpenOptions},
-    mem,
-    sync::{
+    array::TryFromSliceError, cell::UnsafeCell, convert::TryInto, ffi::c_void, fs::{File, OpenOptions}, mem, sync::{
         atomic::Ordering::{Acquire, Relaxed, Release},
         Arc,
-    },
-    time::{Duration, Instant},
+    }, time::{Duration, Instant}
 };
 use tempfile::NamedTempFile;
 use thiserror::Error as ThisError;
@@ -92,6 +86,9 @@ pub enum Error {
     /// Wrapped bincode error encountered during (de)serialization.
     #[error(transparent)]
     Bincode(#[from] bincode::Error),
+
+    #[error(transparent)]
+    TryFrom(#[from] TryFromSliceError),
 }
 
 /// `ipmpsc`-specific Result type alias
@@ -114,6 +111,20 @@ fn map(file: &File) -> Result<MmapMut> {
 
         Ok(map)
     }
+}
+
+pub trait ShmSerializer {
+    fn serialize(&self) -> Result<Vec<u8>>;
+}
+
+// pub trait ShmDeserializer {
+//     fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> Result<Self> where Self: Sized;
+// }
+pub trait ShmZeroCopyDeserializer<'de>: Sized {
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> Result<Self>;
+}
+pub trait ShmDeserializer: Sized {
+    fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self>;
 }
 
 /// Represents a file-backed shared memory ring buffer, suitable for constructing a
@@ -222,11 +233,9 @@ impl Receiver {
     /// Attempt to read a message without blocking.
     ///
     /// This will return `Ok(None)` if there are no messages immediately available.
-    pub fn try_recv<T>(&self) -> Result<Option<T>>
-    where
-        T: for<'de> Deserialize<'de>,
+    pub fn try_recv<T: ShmDeserializer>(&self) -> Result<Option<T>>
     {
-        Ok(if let Some((value, position)) = self.try_recv_0()? {
+        Ok(if let Some((value, position)) = self.try_recv_0::<T>()? {
             self.seek(position)?;
 
             Some(value)
@@ -235,7 +244,7 @@ impl Receiver {
         })
     }
 
-    fn try_recv_0<'a, T: Deserialize<'a>>(&'a self) -> Result<Option<(T, u32)>> {
+    fn try_recv_0<'a, T: ShmDeserializer>(&'a self) -> Result<Option<(T, u32)>> {
         let buffer = self.0 .0.buffer();
         let map = buffer.map();
 
@@ -246,11 +255,45 @@ impl Receiver {
             if write != read {
                 let slice = map.as_ref();
                 let start = read + 4;
-                let size = bincode::deserialize::<u32>(&slice[read as usize..start as usize])?;
+                let size = u32::from_le_bytes(slice[read as usize..start as usize].try_into()?);
+
                 if size > 0 {
                     let end = start + size;
                     break Some((
-                        bincode::deserialize(&slice[start as usize..end as usize])?,
+                        T::deserialize_from_bytes(&slice[start as usize..end as usize])?,
+                        end,
+                    ));
+                } else if write < read {
+                    read = BEGINNING;
+                    let mut lock = buffer.lock()?;
+                    buffer.header().read.store(read, Relaxed);
+                    lock.notify_all()?;
+                } else {
+                    return Err(Error::Runtime("corrupt ring buffer".into()));
+                }
+            } else {
+                break None;
+            }
+        })
+    }
+
+    fn try_zc_recv_0<'a, T: ShmZeroCopyDeserializer<'a>>(&'a self) -> Result<Option<(T, u32)>> {
+        let buffer = self.0 .0.buffer();
+        let map = buffer.map();
+
+        let mut read = buffer.header().read.load(Relaxed);
+        let write = buffer.header().write.load(Acquire);
+
+        Ok(loop {
+            if write != read {
+                let slice = map.as_ref();
+                let start = read + 4;
+                let size = u32::from_le_bytes(slice[read as usize..start as usize].try_into()?);
+
+                if size > 0 {
+                    let end = start + size;
+                    break Some((
+                        T::deserialize_from_bytes(&slice[start as usize..end as usize])?,
                         end,
                     ));
                 } else if write < read {
@@ -268,11 +311,9 @@ impl Receiver {
     }
 
     /// Attempt to read a message, blocking if necessary until one becomes available.
-    pub fn recv<T>(&self) -> Result<T>
-    where
-        T: for<'de> Deserialize<'de>,
+    pub fn recv<T: ShmDeserializer>(&self) -> Result<T>
     {
-        let (value, position) = self.recv_timeout_0(None)?.unwrap();
+        let (value, position) = self.recv_timeout_0::<T>(None)?.unwrap();
 
         self.seek(position)?;
 
@@ -281,12 +322,10 @@ impl Receiver {
 
     /// Attempt to read a message, blocking for up to the specified duration if necessary until one becomes
     /// available.
-    pub fn recv_timeout<T>(&self, timeout: Duration) -> Result<Option<T>>
-    where
-        T: for<'de> Deserialize<'de>,
+    pub fn recv_timeout<T: ShmDeserializer>(&self, timeout: Duration) -> Result<Option<T>>
     {
         Ok(
-            if let Some((value, position)) = self.recv_timeout_0(Some(timeout))? {
+            if let Some((value, position)) = self.recv_timeout_0::<T>(Some(timeout))? {
                 self.seek(position)?;
 
                 Some(value)
@@ -320,13 +359,43 @@ impl Receiver {
         }
     }
 
-    fn recv_timeout_0<'a, T: Deserialize<'a>>(
+    fn recv_timeout_0<'a, T: ShmDeserializer>(
         &'a self,
         timeout: Option<Duration>,
     ) -> Result<Option<(T, u32)>> {
         let mut deadline = None;
         loop {
-            if let Some(value_and_position) = self.try_recv_0()? {
+            if let Some(value_and_position) = self.try_recv_0::<T>()? {
+                return Ok(Some(value_and_position));
+            }
+
+            let buffer = self.0 .0.buffer();
+
+            let mut now = Instant::now();
+            deadline = deadline.or_else(|| timeout.map(|timeout| now + timeout));
+
+            let read = buffer.header().read.load(Relaxed);
+
+            let mut lock = buffer.lock()?;
+            while read == buffer.header().write.load(Acquire) {
+                if deadline.map(|deadline| deadline > now).unwrap_or(true) {
+                    lock.timed_wait(&self.0 .0, deadline.map(|deadline| deadline - now))?;
+
+                    now = Instant::now();
+                } else {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    fn recv_zc_timeout_0<'a, T: ShmZeroCopyDeserializer<'a>>(
+        &'a self,
+        timeout: Option<Duration>,
+    ) -> Result<Option<(T, u32)>> {
+        let mut deadline = None;
+        loop {
+            if let Some(value_and_position) = self.try_zc_recv_0::<T>()? {
                 return Ok(Some(value_and_position));
             }
 
@@ -371,12 +440,12 @@ impl<'a> ZeroCopyContext<'a> {
     /// This will return `Ok(None)` if there are no messages immediately available.  It will return
     /// `Err(`[`Error::AlreadyReceived`](enum.Error.html#variant.AlreadyReceived)`))` if this instance has already
     /// been used to read a message.
-    pub fn try_recv<'b, T: Deserialize<'b>>(&'b mut self) -> Result<Option<T>> {
+    pub fn try_recv<'b, T: ShmZeroCopyDeserializer<'b>>(&'b mut self) -> Result<Option<T>> {
         if self.position.is_some() {
             Err(Error::AlreadyReceived)
         } else {
             Ok(
-                if let Some((value, position)) = self.receiver.try_recv_0()? {
+                if let Some((value, position)) = self.receiver.try_zc_recv_0::<T>()? {
                     self.position = Some(position);
                     Some(value)
                 } else {
@@ -390,8 +459,8 @@ impl<'a> ZeroCopyContext<'a> {
     ///
     /// This will return `Err(`[`Error::AlreadyReceived`](enum.Error.html#variant.AlreadyReceived)`))` if this
     /// instance has already been used to read a message.
-    pub fn recv<'b, T: Deserialize<'b>>(&'b mut self) -> Result<T> {
-        let (value, position) = self.receiver.recv_timeout_0(None)?.unwrap();
+    pub fn recv<'b, T: ShmZeroCopyDeserializer<'b>>(&'b mut self) -> Result<T> {
+        let (value, position) = self.receiver.recv_zc_timeout_0::<T>(None)?.unwrap();
 
         self.position = Some(position);
 
@@ -403,7 +472,7 @@ impl<'a> ZeroCopyContext<'a> {
     ///
     /// This will return `Err(`[`Error::AlreadyReceived`](enum.Error.html#variant.AlreadyReceived)`))` if this
     /// instance has already been used to read a message.
-    pub fn recv_timeout<'b, T: Deserialize<'b>>(
+    pub fn recv_timeout<'b, T: ShmZeroCopyDeserializer<'b>>(
         &'b mut self,
         timeout: Duration,
     ) -> Result<Option<T>> {
@@ -411,7 +480,7 @@ impl<'a> ZeroCopyContext<'a> {
             Err(Error::AlreadyReceived)
         } else {
             Ok(
-                if let Some((value, position)) = self.receiver.recv_timeout_0(Some(timeout))? {
+                if let Some((value, position)) = self.receiver.recv_zc_timeout_0::<T>(Some(timeout))? {
                     self.position = Some(position);
                     Some(value)
                 } else {
@@ -448,8 +517,8 @@ impl Sender {
     /// `Err(`[`Error::ZeroSizedMessage`](enum.Error.html#variant.ZeroSizedMessage)`))`.  If the serialized size is
     /// greater than the ring buffer capacity, this method will return
     /// `Err(`[`Error::MessageTooLarge`](enum.Error.html#variant.MessageTooLarge)`))`.
-    pub fn send(&self, value: &impl Serialize) -> Result<()> {
-        self.send_timeout_0(value, false, None).map(drop)
+    pub fn send<T: ShmSerializer>(&self, value: &T) -> Result<()> {
+        self.send_timeout_0::<T>(value, false, None).map(drop)
     }
 
     /// Send the specified message, waiting for sufficient contiguous space to become available in the ring buffer
@@ -461,8 +530,8 @@ impl Sender {
     /// `Err(`[`Error::ZeroSizedMessage`](enum.Error.html#variant.ZeroSizedMessage)`))`.  If the serialized size is
     /// greater than the ring buffer capacity, this method will return
     /// `Err(`[`Error::MessageTooLarge`](enum.Error.html#variant.MessageTooLarge)`))`.
-    pub fn send_timeout(&self, value: &impl Serialize, timeout: Duration) -> Result<bool> {
-        self.send_timeout_0(value, false, Some(timeout))
+    pub fn send_timeout<T: ShmSerializer>(&self, value: &T, timeout: Duration) -> Result<bool> {
+        self.send_timeout_0::<T>(value, false, Some(timeout))
     }
 
     /// Send the specified message, waiting for the ring buffer to become completely empty first.
@@ -474,20 +543,25 @@ impl Sender {
     /// `Err(`[`Error::ZeroSizedMessage`](enum.Error.html#variant.ZeroSizedMessage)`))`.  If the serialized size
     /// is greater than the ring buffer capacity, this method will return
     /// `Err(`[`Error::MessageTooLarge`](enum.Error.html#variant.MessageTooLarge)`))`.
-    pub fn send_when_empty(&self, value: &impl Serialize) -> Result<()> {
-        self.send_timeout_0(value, true, None).map(drop)
+    pub fn send_when_empty<T: ShmSerializer>(&self, value: &T) -> Result<()> {
+        self.send_timeout_0::<T>(value, true, None).map(drop)
     }
 
-    fn send_timeout_0(
+    fn send_timeout_0<T: ShmSerializer>(
         &self,
-        value: &impl Serialize,
+        value: &impl ShmSerializer,
         wait_until_empty: bool,
         timeout: Option<Duration>,
     ) -> Result<bool> {
         let buffer = self.0 .0.buffer();
         let map = self.0 .0.map_mut();
 
-        let size = bincode::serialized_size(value)? as u32;
+        let bytes = value.serialize()?;
+
+        let size = bytes.len() as u32;
+
+        // DELETE
+        // let size = bincode::serialized_size(value)? as u32;
 
         if size == 0 {
             return Err(Error::ZeroSizedMessage);
@@ -512,10 +586,8 @@ impl Sender {
                 } else if read != BEGINNING {
                     assert!(write > BEGINNING);
 
-                    bincode::serialize_into(
-                        &mut map[write as usize..(write + 4) as usize],
-                        &0_u32,
-                    )?;
+                    map[write as usize..(write + 4) as usize].copy_from_slice(&0_u32.to_le_bytes());
+
                     write = BEGINNING;
                     buffer.header().write.store(write, Release);
                     lock.notify_all()?;
@@ -536,10 +608,14 @@ impl Sender {
         }
 
         let start = write + 4;
-        bincode::serialize_into(&mut map[write as usize..start as usize], &size)?;
+        map[write as usize..start as usize].copy_from_slice(&size.to_le_bytes());
+        // DELETE
+        //bincode::serialize_into(&mut map[write as usize..start as usize], &size)?;
 
         let end = start + size;
-        bincode::serialize_into(&mut map[start as usize..end as usize], value)?;
+        map[start as usize..end as usize].copy_from_slice(&bytes);
+        // DELETE
+        // bincode::serialize_into(&mut map[start as usize..end as usize], value)?;
 
         buffer.header().write.store(end, Release);
 
@@ -554,7 +630,40 @@ mod tests {
     use super::*;
     use anyhow::{anyhow, Result};
     use proptest::{arbitrary::any, collection::vec, prop_assume, proptest, strategy::Strategy};
+    use serde::{Serialize, Deserialize};
     use std::thread;
+
+    #[derive(Debug)]
+    pub struct BincodeZeroCopyDeserializer<T>(pub T);
+
+    impl<'de, T> ShmZeroCopyDeserializer<'de> for BincodeZeroCopyDeserializer<T>
+    where
+        T: Deserialize<'de>,
+    {
+        fn deserialize_from_bytes(bytes: &'de [u8]) -> super::Result<Self> {
+            Ok(Self(bincode::deserialize::<T>(bytes)?))
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct BincodeDeserializer<T>(pub T);
+
+    impl<T> ShmDeserializer for BincodeDeserializer<T>
+    where T: for<'de> Deserialize<'de>
+    {
+        fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> super::Result<Self> {
+            Ok(Self(bincode::deserialize::<T>(bytes)?))
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct BincodeSerializer<T: Serialize>(pub T);
+
+    impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
+        fn serialize(&self) -> super::Result<Vec<u8>> {
+            Ok(bincode::serialize(&self.0)?)
+        }
+    }
 
     #[derive(Debug)]
     struct Case {
@@ -573,8 +682,8 @@ mod tests {
                 let expected = self.data.clone();
                 thread::spawn(move || -> Result<()> {
                     for item in &expected {
-                        let received = rx.recv::<Vec<u8>>()?;
-                        assert_eq!(item, &received);
+                        let received = rx.recv::<BincodeDeserializer::<Vec<u8>>>()?;
+                        assert_eq!(item, &received.0);
                     }
 
                     Ok(())
@@ -585,7 +694,7 @@ mod tests {
                 let expected = self.data.len() * self.sender_count as usize;
                 thread::spawn(move || -> Result<()> {
                     for _ in 0..expected {
-                        rx.recv::<Vec<u8>>()?;
+                        rx.recv::<BincodeDeserializer::<Vec<u8>>>()?;
                     }
                     Ok(())
                 })
@@ -601,7 +710,7 @@ mod tests {
                             let tx = Sender::new(SharedRingBuffer::open(&name)?);
 
                             for item in data.as_ref() {
-                                tx.send(item)?;
+                                tx.send(&BincodeSerializer(item))?;
                             }
 
                             Ok(())
@@ -662,17 +771,17 @@ mod tests {
         let mut rx = Receiver::new(buffer);
         let tx = Sender::new(SharedRingBuffer::open(&name)?);
 
-        tx.send(&sent)?;
-        tx.send(&42_u32)?;
+        tx.send(&BincodeSerializer(&sent))?;
+        tx.send(&BincodeSerializer(42_u32))?;
 
         {
             let mut rx = rx.zero_copy_context();
-            let received = rx.recv()?;
+            let received = rx.recv::<BincodeZeroCopyDeserializer<Foo>>()?;
 
-            assert_eq!(sent, received);
+            assert_eq!(sent, received.0);
         }
 
-        assert_eq!(42_u32, rx.recv()?);
+        assert_eq!(42_u32, rx.recv::<BincodeDeserializer<u32>>()?.0);
 
         Ok(())
     }
@@ -685,12 +794,12 @@ mod tests {
 
         let sender = os::test::fork(move || {
             thread::sleep(Duration::from_secs(1));
-            tx.send(&42_u32).map_err(anyhow::Error::from)
+            tx.send(&BincodeSerializer(42_u32)).map_err(anyhow::Error::from)
         })?;
 
         loop {
-            if let Some(value) = rx.recv_timeout(Duration::from_millis(1))? {
-                assert_eq!(42_u32, value);
+            if let Some(value) = rx.recv_timeout::<BincodeDeserializer<u32>>(Duration::from_millis(1))? {
+                assert_eq!(42_u32, value.0);
                 break;
             }
         }
@@ -707,13 +816,13 @@ mod tests {
         let tx = Sender::new(SharedRingBuffer::open(&name)?);
 
         let sender = os::test::fork(move || loop {
-            if tx.send_timeout(&42_u32, Duration::from_millis(1))? {
+            if tx.send_timeout(&BincodeSerializer(42_u32), Duration::from_millis(1))? {
                 break Ok(());
             }
         })?;
 
         thread::sleep(Duration::from_secs(1));
-        assert_eq!(42_u32, rx.recv()?);
+        assert_eq!(42_u32, rx.recv::<BincodeDeserializer<u32>>()?.0);
 
         sender.join().map_err(|e| anyhow!("{:?}", e))??;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,18 @@
 use memmap2::MmapMut;
 use os::{Buffer, Header, View};
 use std::{
-    array::TryFromSliceError, cell::UnsafeCell, convert::TryInto, ffi::c_void, fs::{File, OpenOptions}, mem, sync::{
+    array::TryFromSliceError,
+    cell::UnsafeCell,
+    convert::TryInto,
+    ffi::c_void,
+    fmt::{Debug, Display},
+    fs::{File, OpenOptions},
+    mem,
+    sync::{
         atomic::Ordering::{Acquire, Relaxed, Release},
         Arc,
-    }, time::{Duration, Instant}
+    },
+    time::{Duration, Instant},
 };
 use tempfile::NamedTempFile;
 use thiserror::Error as ThisError;
@@ -83,9 +91,9 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    /// Wrapped bincode error encountered during (de)serialization.
+    /// Errors from ser/deser operations.
     #[error(transparent)]
-    Bincode(#[from] bincode::Error),
+    Serialize(#[from] SerializeError),
 
     /// Errors from converting little endian bytes to u32 will be caught here.
     #[error(transparent)]
@@ -114,21 +122,39 @@ fn map(file: &File) -> Result<MmapMut> {
     }
 }
 
+/// `ipmpsc`-specific error type
+#[derive(ThisError, Debug)]
+pub enum SerializeError {
+    #[error("failed to serialize: {0:?} => {1}@{2}")]
+    FailedSerialize(String, u32, &'static str),
+
+    #[error("failed to deserialize: {0:?} => {1}@{2}")]
+    FailedDeserialize(String, u32, &'static str),
+}
+
+pub type SerializeResult<T> = std::result::Result<T, SerializeError>;
+
 /// Trait apis to decouple the serialization backend from the mechanical send/recv
 /// For a writer to work the payload must implement this trait
 pub trait ShmSerializer {
-    fn serialize(&self) -> Result<Vec<u8>>;
+    type Error: Display;
+
+    fn serialize(&self) -> std::result::Result<Vec<u8>, Self::Error>;
 }
 
 /// For a reader to work they payload must implement this trait
 pub trait ShmDeserializer: Sized {
-    fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self>;
+    type Error: Display;
+
+    fn deserialize_from_bytes(bytes: &[u8]) -> std::result::Result<Self, Self::Error>;
 }
 
 /// To use the zero_copy_context the payload must implement this trait allowing for more
 /// explict lifetimes
 pub trait ShmZeroCopyDeserializer<'de>: Sized {
-    fn deserialize_from_bytes(bytes: &'de [u8]) -> Result<Self>;
+    type Error: Display;
+
+    fn deserialize_from_bytes(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error>;
 }
 
 /// Represents a file-backed shared memory ring buffer, suitable for constructing a
@@ -237,8 +263,7 @@ impl Receiver {
     /// Attempt to read a message without blocking.
     ///
     /// This will return `Ok(None)` if there are no messages immediately available.
-    pub fn try_recv<T: ShmDeserializer>(&self) -> Result<Option<T>>
-    {
+    pub fn try_recv<T: ShmDeserializer>(&self) -> Result<Option<T>> {
         Ok(if let Some((value, position)) = self.try_recv_0::<T>()? {
             self.seek(position)?;
 
@@ -264,7 +289,15 @@ impl Receiver {
                 if size > 0 {
                     let end = start + size;
                     break Some((
-                        T::deserialize_from_bytes(&slice[start as usize..end as usize])?,
+                        T::deserialize_from_bytes(&slice[start as usize..end as usize]).map_err(
+                            |e| {
+                                Error::Serialize(SerializeError::FailedDeserialize(
+                                    e.to_string(),
+                                    line!(),
+                                    file!(),
+                                ))
+                            },
+                        )?,
                         end,
                     ));
                 } else if write < read {
@@ -297,7 +330,15 @@ impl Receiver {
                 if size > 0 {
                     let end = start + size;
                     break Some((
-                        T::deserialize_from_bytes(&slice[start as usize..end as usize])?,
+                        T::deserialize_from_bytes(&slice[start as usize..end as usize]).map_err(
+                            |e| {
+                                Error::Serialize(SerializeError::FailedDeserialize(
+                                    e.to_string(),
+                                    line!(),
+                                    file!(),
+                                ))
+                            },
+                        )?,
                         end,
                     ));
                 } else if write < read {
@@ -315,8 +356,7 @@ impl Receiver {
     }
 
     /// Attempt to read a message, blocking if necessary until one becomes available.
-    pub fn recv<T: ShmDeserializer>(&self) -> Result<T>
-    {
+    pub fn recv<T: ShmDeserializer>(&self) -> Result<T> {
         let (value, position) = self.recv_timeout_0::<T>(None)?.unwrap();
 
         self.seek(position)?;
@@ -326,8 +366,7 @@ impl Receiver {
 
     /// Attempt to read a message, blocking for up to the specified duration if necessary until one becomes
     /// available.
-    pub fn recv_timeout<T: ShmDeserializer>(&self, timeout: Duration) -> Result<Option<T>>
-    {
+    pub fn recv_timeout<T: ShmDeserializer>(&self, timeout: Duration) -> Result<Option<T>> {
         Ok(
             if let Some((value, position)) = self.recv_timeout_0::<T>(Some(timeout))? {
                 self.seek(position)?;
@@ -484,7 +523,9 @@ impl<'a> ZeroCopyContext<'a> {
             Err(Error::AlreadyReceived)
         } else {
             Ok(
-                if let Some((value, position)) = self.receiver.recv_zc_timeout_0::<T>(Some(timeout))? {
+                if let Some((value, position)) =
+                    self.receiver.recv_zc_timeout_0::<T>(Some(timeout))?
+                {
                     self.position = Some(position);
                     Some(value)
                 } else {
@@ -560,7 +601,13 @@ impl Sender {
         let buffer = self.0 .0.buffer();
         let map = self.0 .0.map_mut();
 
-        let bytes = value.serialize()?;
+        let bytes = value.serialize().map_err(|e| {
+            Error::Serialize(SerializeError::FailedSerialize(
+                e.to_string(),
+                line!(),
+                file!(),
+            ))
+        })?;
 
         let size = bytes.len() as u32;
 
@@ -627,7 +674,7 @@ mod tests {
     use super::*;
     use anyhow::{anyhow, Result};
     use proptest::{arbitrary::any, collection::vec, prop_assume, proptest, strategy::Strategy};
-    use serde::{Serialize, Deserialize};
+    use serde::{Deserialize, Serialize};
     use std::thread;
 
     #[derive(Debug)]
@@ -637,7 +684,9 @@ mod tests {
     where
         T: Deserialize<'de>,
     {
-        fn deserialize_from_bytes(bytes: &'de [u8]) -> super::Result<Self> {
+        type Error = bincode::Error;
+
+        fn deserialize_from_bytes(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
             Ok(Self(bincode::deserialize::<T>(bytes)?))
         }
     }
@@ -646,9 +695,12 @@ mod tests {
     pub struct BincodeDeserializer<T>(pub T);
 
     impl<T> ShmDeserializer for BincodeDeserializer<T>
-    where T: for<'de> Deserialize<'de>
+    where
+        T: for<'de> Deserialize<'de>,
     {
-        fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> super::Result<Self> {
+        type Error = bincode::Error;
+
+        fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
             Ok(Self(bincode::deserialize::<T>(bytes)?))
         }
     }
@@ -657,7 +709,9 @@ mod tests {
     pub struct BincodeSerializer<T: Serialize>(pub T);
 
     impl<T: Serialize> ShmSerializer for BincodeSerializer<T> {
-        fn serialize(&self) -> super::Result<Vec<u8>> {
+        type Error = bincode::Error;
+
+        fn serialize(&self) -> std::result::Result<Vec<u8>, Self::Error> {
             Ok(bincode::serialize(&self.0)?)
         }
     }
@@ -679,7 +733,7 @@ mod tests {
                 let expected = self.data.clone();
                 thread::spawn(move || -> Result<()> {
                     for item in &expected {
-                        let received = rx.recv::<BincodeDeserializer::<Vec<u8>>>()?;
+                        let received = rx.recv::<BincodeDeserializer<Vec<u8>>>()?;
                         assert_eq!(item, &received.0);
                     }
 
@@ -691,7 +745,7 @@ mod tests {
                 let expected = self.data.len() * self.sender_count as usize;
                 thread::spawn(move || -> Result<()> {
                     for _ in 0..expected {
-                        rx.recv::<BincodeDeserializer::<Vec<u8>>>()?;
+                        rx.recv::<BincodeDeserializer<Vec<u8>>>()?;
                     }
                     Ok(())
                 })
@@ -791,11 +845,14 @@ mod tests {
 
         let sender = os::test::fork(move || {
             thread::sleep(Duration::from_secs(1));
-            tx.send(&BincodeSerializer(42_u32)).map_err(anyhow::Error::from)
+            tx.send(&BincodeSerializer(42_u32))
+                .map_err(anyhow::Error::from)
         })?;
 
         loop {
-            if let Some(value) = rx.recv_timeout::<BincodeDeserializer<u32>>(Duration::from_millis(1))? {
+            if let Some(value) =
+                rx.recv_timeout::<BincodeDeserializer<u32>>(Duration::from_millis(1))?
+            {
                 assert_eq!(42_u32, value.0);
                 break;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Inter-Process Multiple Producer, Single Consumer Channels for Rust
 //!
 //! This library provides a type-safe, high-performance inter-process channel implementation based on a shared
-//! memory ring buffer.  It uses [bincode](https://github.com/TyOverby/bincode) for (de)serialization, including
+//! memory ring buffer.  It is agnostic to (de)serialization backends and includes the capability for
 //! zero-copy deserialization, making it ideal for messages with large `&str` or `&[u8]` fields.  And it has a name
 //! that rolls right off the tongue.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ impl Receiver {
     /// 3. A given [`ZeroCopyContext`](struct.ZeroCopyContext.html) can only be used to deserialize a single
     /// message before it must be discarded since the read pointer is advanced only when the instance is dropped
     /// (enforced at run time).
-    pub fn zero_copy_context(&mut self) -> ZeroCopyContext {
+    pub fn zero_copy_context(&mut self) -> ZeroCopyContext<'_> {
         ZeroCopyContext {
             receiver: self,
             position: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,6 @@ pub trait ShmSerializer {
     fn serialize(&self) -> Result<Vec<u8>>;
 }
 
-// pub trait ShmDeserializer {
-//     fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> Result<Self> where Self: Sized;
-// }
 pub trait ShmZeroCopyDeserializer<'de>: Sized {
     fn deserialize_from_bytes(bytes: &'de [u8]) -> Result<Self>;
 }
@@ -560,9 +557,6 @@ impl Sender {
 
         let size = bytes.len() as u32;
 
-        // DELETE
-        // let size = bincode::serialized_size(value)? as u32;
-
         if size == 0 {
             return Err(Error::ZeroSizedMessage);
         }
@@ -609,13 +603,9 @@ impl Sender {
 
         let start = write + 4;
         map[write as usize..start as usize].copy_from_slice(&size.to_le_bytes());
-        // DELETE
-        //bincode::serialize_into(&mut map[write as usize..start as usize], &size)?;
 
         let end = start + size;
         map[start as usize..end as usize].copy_from_slice(&bytes);
-        // DELETE
-        // bincode::serialize_into(&mut map[start as usize..end as usize], value)?;
 
         buffer.header().write.store(end, Release);
 

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -106,7 +106,7 @@ impl Buffer {
         }
     }
 
-    pub fn lock(&self) -> Result<Lock> {
+    pub fn lock(&self) -> Result<Lock<'_>> {
         Lock::try_new(self)
     }
 
@@ -122,7 +122,7 @@ impl Buffer {
 pub struct Lock<'a>(&'a Buffer);
 
 impl<'a> Lock<'a> {
-    pub fn try_new(buffer: &Buffer) -> Result<Lock> {
+    pub fn try_new(buffer: &Buffer) -> Result<Lock<'_>> {
         unsafe {
             nonzero!(libc::pthread_mutex_lock(buffer.header().mutex.get()))?;
         }


### PR DESCRIPTION
A much belated follow up to address the issues from this [PR](https://github.com/dicej/ipmpsc/pull/9). If this is accepted then I'll close out the older PR. I was never able to figure out the underlying issue in `unsafe` land so opted to eventually go a safer but still quite flexible approach. Instead of having a hard requirement to use `bincode` explicitly under the hood, serialization & deserialization are now managed via `ShmDeserializer`, `ShmZeroCopyDeserializer` and `ShmSerializer` traits. The api is admittedly a bit more verbose then the original but the benefit is that now users can customize the ser backend while keeping the `ipmpsc` api untouched. For example, below is the trait impl for [speedy](https://docs.rs/speedy/latest/speedy/)

```
use speedy::{LittleEndian, Readable, Writable};
use super::*;

#[derive(Debug)]
pub struct SpeedyZeroCopyDeserializer<T>(pub T);

impl<'de, T> ShmZeroCopyDeserializer<'de> for SpeedyZeroCopyDeserializer<T>
where
    T: Readable<'de, LittleEndian>,
{
    type Error = speedy::Error;

    fn deserialize_from_bytes(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
        Ok(Self(T::read_from_buffer(bytes)?))
    }
}

#[derive(Debug)]
pub struct SpeedyDeserializer<T>(pub T);

impl<T> ShmDeserializer for SpeedyDeserializer<T>
where T: for<'de> Readable<'de, LittleEndian>
{
    type Error = speedy::Error;

    fn deserialize_from_bytes<'de>(bytes: &'de [u8]) -> std::result::Result<Self, Self::Error> {
        Ok(Self(T::read_from_buffer(bytes)?))
    }
}

#[derive(Debug)]
pub struct SpeedySerializer<T: Writable<LittleEndian>>(pub T);

impl<T: Writable<LittleEndian>> ShmSerializer for SpeedySerializer<T> {
    type Error = speedy::Error;

    fn serialize(&self) -> std::result::Result<Vec<u8>, Self::Error> {
        Ok(self.0.write_to_vec()?)
    }
}
```

unit tests pass as do the benchmarking tests in `ipc-benchmarks`. Additionally included is a default set of `bincode` wrapper traits to work with existing primitives (`String`, `Vec` etc) but the wrapper can be skipped for net new structs